### PR TITLE
Fix when WordPress API returns multiple pages for one page by slug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.6.7] - 2020-02-28
+### Fixed
+- Fix issue #82 with WordPress returning multiple page when get page by slug
+
 ## [0.6.6] - 2020-02-13
 ### Added
 - Add excerpt and build_version Twig filters

--- a/tests/Frontend/responses/acf/pages.2.json
+++ b/tests/Frontend/responses/acf/pages.2.json
@@ -1,0 +1,176 @@
+[
+  {
+    "id": 50,
+    "date": "2019-02-15T15:19:17",
+    "date_gmt": "2019-02-15T15:19:17",
+    "guid": {
+      "rendered": "http://localhost/?page_id=50"
+    },
+    "modified": "2019-02-15T15:19:17",
+    "modified_gmt": "2019-02-15T15:19:17",
+    "slug": "lorem-ipsum-page-test",
+    "status": "publish",
+    "type": "page",
+    "link": "http://localhost/team/health/",
+    "title": {
+      "rendered": "Lorem ipsum page test 1"
+    },
+    "content": {
+      "rendered": "<p>This is an example page lorem ipsum dolor sit amet et do lorem this is the page content in here from the main WYSIWYG editor.</p>\n",
+      "protected": false
+    },
+    "excerpt": {
+      "rendered": "<p>This is an example page lorem ipsum dolor sit amet et do lorem this is the page content in here from the main WYSIWYG editor.</p>\n",
+      "protected": false
+    },
+    "author": 1,
+    "featured_media": 0,
+    "parent": 0,
+    "menu_order": 0,
+    "comment_status": "closed",
+    "ping_status": "closed",
+    "template": "page-template.php",
+    "meta": [],
+    "acf": [],
+    "_links": {
+      "self": [
+        {
+          "href": "http://localhost/wp-json/wp/v2/pages/85"
+        }
+      ],
+      "collection": [
+        {
+          "href": "http://localhost/wp-json/wp/v2/pages"
+        }
+      ],
+      "about": [
+        {
+          "href": "http://localhost/wp-json/wp/v2/types/page"
+        }
+      ],
+      "author": [
+        {
+          "embeddable": true,
+          "href": "http://localhost/wp-json/wp/v2/users/1"
+        }
+      ],
+      "replies": [
+        {
+          "embeddable": true,
+          "href": "http://localhost/wp-json/wp/v2/comments?post=85"
+        }
+      ],
+      "version-history": [
+        {
+          "count": 1,
+          "href": "http://localhost/wp-json/wp/v2/pages/85/revisions"
+        }
+      ],
+      "predecessor-version": [
+        {
+          "id": 86,
+          "href": "http://localhost/wp-json/wp/v2/pages/85/revisions/86"
+        }
+      ],
+      "wp:attachment": [
+        {
+          "href": "http://localhost/wp-json/wp/v2/media?parent=85"
+        }
+      ],
+      "curies": [
+        {
+          "name": "wp",
+          "href": "https://api.w.org/{rel}",
+          "templated": true
+        }
+      ]
+    }
+  },
+  {
+    "id": 85,
+    "date": "2019-02-15T15:19:17",
+    "date_gmt": "2019-02-15T15:19:17",
+    "guid": {
+      "rendered": "http://localhost/?page_id=85"
+    },
+    "modified": "2019-02-15T15:19:17",
+    "modified_gmt": "2019-02-15T15:19:17",
+    "slug": "lorem-ipsum-page-test",
+    "status": "publish",
+    "type": "page",
+    "link": "http://localhost/health/",
+    "title": {
+      "rendered": "Lorem ipsum page test 2"
+    },
+    "content": {
+      "rendered": "<p>This is an example page lorem ipsum dolor sit amet et do lorem this is the page content in here from the main WYSIWYG editor.</p>\n",
+      "protected": false
+    },
+    "excerpt": {
+      "rendered": "<p>This is an example page lorem ipsum dolor sit amet et do lorem this is the page content in here from the main WYSIWYG editor.</p>\n",
+      "protected": false
+    },
+    "author": 1,
+    "featured_media": 0,
+    "parent": 0,
+    "menu_order": 0,
+    "comment_status": "closed",
+    "ping_status": "closed",
+    "template": "page-template.php",
+    "meta": [],
+    "acf": [],
+    "_links": {
+      "self": [
+        {
+          "href": "http://localhost/wp-json/wp/v2/pages/85"
+        }
+      ],
+      "collection": [
+        {
+          "href": "http://localhost/wp-json/wp/v2/pages"
+        }
+      ],
+      "about": [
+        {
+          "href": "http://localhost/wp-json/wp/v2/types/page"
+        }
+      ],
+      "author": [
+        {
+          "embeddable": true,
+          "href": "http://localhost/wp-json/wp/v2/users/1"
+        }
+      ],
+      "replies": [
+        {
+          "embeddable": true,
+          "href": "http://localhost/wp-json/wp/v2/comments?post=85"
+        }
+      ],
+      "version-history": [
+        {
+          "count": 1,
+          "href": "http://localhost/wp-json/wp/v2/pages/85/revisions"
+        }
+      ],
+      "predecessor-version": [
+        {
+          "id": 86,
+          "href": "http://localhost/wp-json/wp/v2/pages/85/revisions/86"
+        }
+      ],
+      "wp:attachment": [
+        {
+          "href": "http://localhost/wp-json/wp/v2/media?parent=85"
+        }
+      ],
+      "curies": [
+        {
+          "name": "wp",
+          "href": "https://api.w.org/{rel}",
+          "templated": true
+        }
+      ]
+    }
+  }
+]


### PR DESCRIPTION
@sean-dunwoody you can test by using this in your local composer:

`      "studio24/frontend": "dev-hotfix/82"`