### PR TITLE
Fix TableOfContents::parseHeadingsFromHtml() not being recursive

### DIFF
--- a/src/View/TableOfContents.php
+++ b/src/View/TableOfContents.php
@@ -136,11 +136,11 @@ class TableOfContents
                 ];
                 // Add id attribute to content node
                 $node->setAttribute('id', $id);
+            }
 
-                // Parse child elements
-                if (!empty($node->childNodes)) {
-                    $headings = $this->parseHeadingsFromHtml($node->childNodes, $headings);
-                }
+            // Parse child elements
+            if (!empty($node->childNodes)) {
+                $headings = $this->parseHeadingsFromHtml($node->childNodes, $headings);
             }
         }
 


### PR DESCRIPTION
TableOfContents::parseHeadingsFromHtml() didn't go into HTML elements that were not in the list of levels. So for example passing a div containing headings to this function wouldn't return any TOC.

The fix is easy and simply makes sure the recursive call is applied to all elements.

Note: I am unable to run tests so I can't modify them to make sure this new behavior works properly.