### PR TITLE
Fix issue when ToC titles contain special HTML characters

### DIFF
--- a/src/View/TableOfContents/HeadingCollection.php
+++ b/src/View/TableOfContents/HeadingCollection.php
@@ -66,8 +66,8 @@ class HeadingCollection implements \SeekableIterator, \Countable
     {
         foreach ($collection as $heading) {
             $link = $doc->createElement('a');
-            $link->setAttribute('href', $heading->link);
-            $link->nodeValue = $heading->name;
+            $link->setAttribute('href', htmlentities($heading->link));
+            $link->nodeValue = htmlentities($heading->name);
 
             $listItem =  $doc->createElement('li');
             $listItem->appendChild($link);


### PR DESCRIPTION
If titles contain special characters such as &, Strata throws the following exception in dev:
```An exception has been thrown during the rendering of a template ("Warning: Strata\Frontend\View\TableOfContents\HeadingCollection::buildListItems(): unterminated entity reference Industry Sponsor").```
And produces empty items in prod.

This PR simply escapes that content.